### PR TITLE
puppet4 quickfixes

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -94,6 +94,7 @@ class newrelic::agent::php (
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:
     exec_path            => $newrelic_php_exec_path,
     newrelic_license_key => $newrelic_license_key,
+    newrelic_ini_appname => $newrelic_ini_appname,
     before               => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
     require              => Package[$newrelic_php_package],
     notify               => Service[$newrelic_php_service],

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -108,6 +108,7 @@ define newrelic::php (
 
   ::newrelic::php::newrelic_ini { $newrelic_php_conf_dir:
     newrelic_license_key => $newrelic_license_key,
+    newrelic_ini_appname => $newrelic_ini_appname,
     before               => [ File['/etc/newrelic/newrelic.cfg'], Service[$newrelic_php_service] ],
     require              => Package[$newrelic_php_package],
     notify               => Service[$newrelic_php_service],

--- a/manifests/php/newrelic_ini.pp
+++ b/manifests/php/newrelic_ini.pp
@@ -1,6 +1,7 @@
 # This module should not be used directly. It is used by newrelic::php.
 define newrelic::php::newrelic_ini (
   $newrelic_license_key,
+  $newrelic_ini_appname,
   $exec_path,
 ) {
 


### PR DESCRIPTION
quickfixes for puppet4 only (appname), the template does not get the variables anymore in puppet4+, this needs a complete rework. 